### PR TITLE
Update Formula Stocks portfolio link and screenshot

### DIFF
--- a/src/components/Sections/Portfolio.astro
+++ b/src/components/Sections/Portfolio.astro
@@ -19,8 +19,8 @@ import PortfolioItem from "@/components/PortfolioItem.astro";
     <PortfolioItem
       title="Formula Stocks"
       description="Value/Growth investment research platform"
-      url="https://formulastocks.com"
-      imgSrc="/screenshots/formulastocks.webp"
+      url="https://formulastocks.com/alt"
+      imgSrc="/screenshots/formulastocks_alt.webp"
     />
     <PortfolioItem
       title="Colony Networks"


### PR DESCRIPTION
## Summary
- update the Formula Stocks portfolio item URL to `https://formulastocks.com/alt`
- switch the associated screenshot to `formulastocks_alt.webp`

## Testing
- Not run (not requested)